### PR TITLE
fix: remove docker-compose from frontend GitHub Actions workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,9 +18,12 @@ jobs:
           docker --version
           docker ps
 
-      - name: Build Docker image with docker-compose
+      - name: Build Docker image
         run: |
-          docker compose build
+          docker build -t sonar-frontend:latest .
+
+      - name: Save Docker image to file
+        run: |
           docker save sonar-frontend:latest > sonar-frontend.tar
 
       - name: Copy image to Test Server


### PR DESCRIPTION
Removed docker-compose build/run commands from frontend.yml workflow. Switching to native Docker CLI to comply with GitHub security rules and simplify CI/CD pipeline.